### PR TITLE
Pull the docker image from the registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ LABEL "com.github.actions.color"="orange"
 LABEL "repository"="https://github.com/ambientlight/amplify-cli-action"
 LABEL "homepage"="https://github.com/ambientlight/amplify-cli-action.git"
 
+LABEL org.opencontainers.image.source=https://github.com/ambientlight/amplify-cli-action
+
 RUN npm install --global --unsafe-perm @aws-amplify/cli@latest
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -287,3 +287,19 @@ jobs:
 ```
 
 As an alternative, one practical way could be to have a fixed sandbox environment that all PRs will update regardless of the branch (and doesn't get undeployed), so it can be used as a playground to manually test and play around with upcoming updates, but kind in mind there can be potential additional costs involved as some AWS resources used in amplify have fixed by-hours costs (kinesis for example).
+
+
+## Development
+
+How to roll out a new image
+
+``` bash
+VERSION=0.3.0
+
+docker build -t amplify-cli-action:$VERSION .
+
+docker tag amplify-cli-action:$VERSION ghcr.io/ambientlight/amplify-cli-action/amplify-cli-action:$VERSION
+
+docker push ghcr.io/ambientlight/amplify-cli-action/amplify-cli-action:$VERSION
+
+```

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     default: ''
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/ambientlight/amplify-cli-action/amplify-cli-action:0.3.0'
   args:
     - ${{ inputs.project_dir }}
     - ${{ inputs.source_dir }}


### PR DESCRIPTION
This significantly speeds up build time as the npm install is already
done.